### PR TITLE
Install the client-side app as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,6 +532,5209 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true
     },
+    "discursor-app": {
+      "version": "file:app",
+      "dependencies": {
+        "abab": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "accepts": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "acorn": {
+          "version": "5.0.3",
+          "bundled": true
+        },
+        "acorn-dynamic-import": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
+          }
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
+          }
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "address": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "alphanum-sort": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "anser": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "ansi-align": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "append-transform": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "argparse": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "aria-query": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "array-filter": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "array-map": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-reduce": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "asn1.js": {
+          "version": "4.9.1",
+          "bundled": true
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "ast-types-flow": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "async": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "autoprefixer": {
+          "version": "7.1.1",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "axobject-query": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-core": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babel-eslint": {
+          "version": "7.2.3",
+          "bundled": true
+        },
+        "babel-generator": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-define-map": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-regex": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-jest": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "babel-loader": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "babel-plugin-istanbul": {
+          "version": "4.1.4",
+          "bundled": true
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-dynamic-import": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-react-constant-elements": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-plugin-transform-runtime": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-preset-env": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "babel-preset-flow": {
+          "version": "6.23.0",
+          "bundled": true
+        },
+        "babel-preset-jest": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "babel-preset-react": {
+          "version": "6.24.1",
+          "bundled": true
+        },
+        "babel-preset-react-app": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "babel-register": {
+          "version": "6.24.1",
+          "bundled": true,
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "bundled": true,
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "babel-template": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babel-traverse": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babel-types": {
+          "version": "6.25.0",
+          "bundled": true
+        },
+        "babylon": {
+          "version": "6.17.4",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "batch": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "big.js": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.7",
+          "bundled": true
+        },
+        "bonjour": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true
+        },
+        "boxen": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "bundled": true,
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-aes": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "browserify-cipher": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "browserify-des": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "browserslist": {
+          "version": "2.1.5",
+          "bundled": true
+        },
+        "bser": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true
+        },
+        "buffer-indexof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "caniuse-api": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dependencies": {
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true
+            }
+          }
+        },
+        "caniuse-db": {
+          "version": "1.0.30000696",
+          "bundled": true
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000696",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "case-sensitive-paths-webpack-plugin": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cipher-base": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "circular-json": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "clap": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "clean-css": {
+          "version": "4.1.5",
+          "bundled": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cli-width": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "coa": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "color": {
+          "version": "0.11.4",
+          "bundled": true
+        },
+        "color-convert": {
+          "version": "1.9.0",
+          "bundled": true
+        },
+        "color-name": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "colormin": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "compressible": {
+          "version": "2.0.10",
+          "bundled": true
+        },
+        "compression": {
+          "version": "1.6.2",
+          "bundled": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "bundled": true
+            },
+            "ms": {
+              "version": "0.7.1",
+              "bundled": true
+            }
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "configstore": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dependencies": {
+            "uuid": {
+              "version": "2.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "content-type-parser": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cosmiconfig": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "create-ecdh": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "create-hash": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "create-hmac": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "create-react-class": {
+          "version": "15.6.0",
+          "bundled": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "crypto-browserify": {
+          "version": "3.11.0",
+          "bundled": true
+        },
+        "css-color-names": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "css-loader": {
+          "version": "0.28.4",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dependencies": {
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "css-what": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cssesc": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cssnano": {
+          "version": "3.10.0",
+          "bundled": true,
+          "dependencies": {
+            "autoprefixer": {
+              "version": "6.7.7",
+              "bundled": true
+            },
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "csso": {
+          "version": "2.3.2",
+          "bundled": true
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "bundled": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "deep-diff": {
+          "version": "0.3.8",
+          "bundled": true
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "del": {
+          "version": "2.2.2",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "detect-node": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "detect-port-alt": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "diff": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.2",
+          "bundled": true
+        },
+        "dns-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "dns-packet": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "dns-txt": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "doctrine": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "dom-converter": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "dom-urls": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "domhandler": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "dot-prop": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "dotenv": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.15",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "6.4.3",
+          "bundled": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true
+        },
+        "enhanced-resolve": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "es-abstract": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "es5-ext": {
+          "version": "0.10.23",
+          "bundled": true
+        },
+        "es6-iterator": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "es6-promise": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "bundled": true,
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "3.19.0",
+          "bundled": true,
+          "dependencies": {
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-config-react-app": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "eslint-loader": {
+          "version": "1.7.1",
+          "bundled": true
+        },
+        "eslint-module-utils": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "eslint-plugin-flowtype": {
+          "version": "2.34.0",
+          "bundled": true
+        },
+        "eslint-plugin-import": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dependencies": {
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "5.0.3",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.1.0",
+          "bundled": true
+        },
+        "espree": {
+          "version": "3.4.3",
+          "bundled": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "bundled": true
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "esrecurse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "eventsource": {
+          "version": "0.1.6",
+          "bundled": true
+        },
+        "evp_bytestokey": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "exec-sh": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true
+        },
+        "express": {
+          "version": "4.15.3",
+          "bundled": true,
+          "dependencies": {
+            "array-flatten": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.7",
+              "bundled": true
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "external-editor": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "extract-text-webpack-plugin": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "fastparse": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "fb-watchman": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fbjs": {
+          "version": "0.8.12",
+          "bundled": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "bundled": true
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "file-loader": {
+          "version": "0.11.2",
+          "bundled": true
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fileset": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "filesize": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true
+        },
+        "filled-array": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "finalhandler": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.7",
+              "bundled": true
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "flat-cache": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "flatten": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true
+        },
+        "forwarded": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "fresh": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "optional": true
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "optional": true
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "optional": true
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "bundled": true,
+              "optional": true
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "optional": true
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "optional": true
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "got": {
+          "version": "5.7.1",
+          "bundled": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "growly": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "gzip-size": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "handle-thing": {
+          "version": "1.2.5",
+          "bundled": true
+        },
+        "handlebars": {
+          "version": "4.0.10",
+          "bundled": true,
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.6",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "hash-base": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "hpack.js": {
+          "version": "2.1.6",
+          "bundled": true
+        },
+        "html-comment-regex": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "html-entities": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "html-minifier": {
+          "version": "3.5.2",
+          "bundled": true
+        },
+        "html-webpack-plugin": {
+          "version": "2.29.0",
+          "bundled": true,
+          "dependencies": {
+            "loader-utils": {
+              "version": "0.2.17",
+              "bundled": true
+            }
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "bundled": true,
+          "dependencies": {
+            "domutils": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "http-deceiver": {
+          "version": "1.2.7",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "http-proxy": {
+          "version": "1.16.2",
+          "bundled": true
+        },
+        "http-proxy-middleware": {
+          "version": "0.17.4",
+          "bundled": true,
+          "dependencies": {
+            "is-extglob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.18",
+          "bundled": true
+        },
+        "icss-replace-symbols": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "icss-utils": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.3",
+          "bundled": true
+        },
+        "immutable": {
+          "version": "3.8.1",
+          "bundled": true
+        },
+        "immutable-props": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "indexes-of": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "internal-ip": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "interpret": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "is-absolute-url": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-buffer": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "1.0.10",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-directory": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "is-my-json-valid": {
+          "version": "2.16.0",
+          "bundled": true
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-svg": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "istanbul-api": {
+          "version": "1.1.10",
+          "bundled": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "istanbul-lib-hook": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.7.3",
+          "bundled": true
+        },
+        "istanbul-lib-report": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "istanbul-reports": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "jest": {
+          "version": "20.0.4",
+          "bundled": true,
+          "dependencies": {
+            "callsites": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "jest-cli": {
+              "version": "20.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-config": {
+          "version": "20.0.4",
+          "bundled": true
+        },
+        "jest-diff": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-docblock": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-environment-jsdom": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-environment-node": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-haste-map": {
+          "version": "20.0.4",
+          "bundled": true
+        },
+        "jest-jasmine2": {
+          "version": "20.0.4",
+          "bundled": true
+        },
+        "jest-matcher-utils": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-matchers": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-message-util": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-mock": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-regex-util": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-resolve": {
+          "version": "20.0.4",
+          "bundled": true
+        },
+        "jest-resolve-dependencies": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-runtime": {
+          "version": "20.0.4",
+          "bundled": true,
+          "dependencies": {
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "jest-snapshot": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-util": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "jest-validate": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "js-base64": {
+          "version": "2.1.9",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.7.0",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jschardet": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "jsdom": {
+          "version": "9.12.0",
+          "bundled": true,
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "bundled": true
+            }
+          }
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "json-loader": {
+          "version": "0.5.4",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json3": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "latest-version": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "lazy-req": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "leven": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "loader-fs-cache": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loader-runner": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "loader-utils": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash-es": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "bundled": true
+        },
+        "lodash.cond": {
+          "version": "4.5.2",
+          "bundled": true
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "lodash.memoize": {
+          "version": "4.1.2",
+          "bundled": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "lower-case": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "macaddress": {
+          "version": "0.2.8",
+          "bundled": true
+        },
+        "makeerror": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "math-expression-evaluator": {
+          "version": "1.2.17",
+          "bundled": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "memory-fs": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "meow": {
+          "version": "3.7.0",
+          "bundled": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true
+        },
+        "miller-rabin": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "mime": {
+          "version": "1.3.6",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "minimalistic-assert": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "multicast-dns": {
+          "version": "6.1.1",
+          "bundled": true
+        },
+        "multicast-dns-service-types": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "ncname": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "no-case": {
+          "version": "2.3.1",
+          "bundled": true
+        },
+        "node-fetch": {
+          "version": "1.7.1",
+          "bundled": true
+        },
+        "node-forge": {
+          "version": "0.6.33",
+          "bundled": true
+        },
+        "node-int64": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "node-libs-browser": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dependencies": {
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "node-notifier": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "node-status-codes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "nodejs-websocket": {
+          "version": "1.7.1",
+          "bundled": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "normalize-url": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "nth-check": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "nwmatcher": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-hash": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "obuf": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "opn": {
+          "version": "5.1.0",
+          "bundled": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "original": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dependencies": {
+            "url-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "p-map": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "package-json": {
+          "version": "2.4.0",
+          "bundled": true
+        },
+        "pako": {
+          "version": "0.2.9",
+          "bundled": true
+        },
+        "param-case": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "parse-asn1": {
+          "version": "5.1.0",
+          "bundled": true
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "pbkdf2": {
+          "version": "3.0.12",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "portfinder": {
+          "version": "1.0.13",
+          "bundled": true,
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            }
+          }
+        },
+        "postcss": {
+          "version": "6.0.5",
+          "bundled": true,
+          "dependencies": {
+            "chalk": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-calc": {
+          "version": "5.3.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-colormin": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-convert-values": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-discard-duplicates": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-discard-empty": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-discard-overridden": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-discard-unused": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-filter-plugins": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-flexbugs-fixes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "postcss-load-config": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "postcss-load-options": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "postcss-load-plugins": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "postcss-loader": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "postcss-merge-idents": {
+          "version": "2.1.7",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-merge-longhand": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dependencies": {
+            "browserslist": {
+              "version": "1.7.7",
+              "bundled": true
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-message-helpers": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "postcss-minify-font-values": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-minify-params": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "postcss-modules-scope": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "postcss-modules-values": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "postcss-normalize-charset": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "3.0.8",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-reduce-idents": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "2.2.3",
+          "bundled": true
+        },
+        "postcss-svgo": {
+          "version": "2.1.6",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "postcss-zindex": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "postcss": {
+              "version": "5.2.17",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            }
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pretty-bytes": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "pretty-error": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "pretty-format": {
+          "version": "20.0.3",
+          "bundled": true
+        },
+        "private": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.5.10",
+          "bundled": true
+        },
+        "proxy-addr": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "prr": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "q": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "bundled": true
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "querystringify": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "ramda": {
+          "version": "0.24.1",
+          "bundled": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "randombytes": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "react": {
+          "version": "15.6.1",
+          "bundled": true
+        },
+        "react-dev-utils": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cli-cursor": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "figures": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "inquirer": {
+              "version": "3.1.1",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.7",
+              "bundled": true
+            },
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "restore-cursor": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "run-async": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "rx-lite": {
+              "version": "4.0.8",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "react-dom": {
+          "version": "15.6.1",
+          "bundled": true
+        },
+        "react-error-overlay": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dependencies": {
+            "anser": {
+              "version": "1.2.5",
+              "bundled": true
+            }
+          }
+        },
+        "react-immutable": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "react-redux": {
+          "version": "5.0.5",
+          "bundled": true
+        },
+        "react-scripts": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dependencies": {
+            "promise": {
+              "version": "7.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "read-all-stream": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "readline2": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true
+        },
+        "recursive-readdir": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "reduce-css-calc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            }
+          }
+        },
+        "reduce-function-call": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            }
+          }
+        },
+        "redux": {
+          "version": "3.7.1",
+          "bundled": true
+        },
+        "redux-immutable": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "redux-logger": {
+          "version": "3.0.6",
+          "bundled": true
+        },
+        "regenerate": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.9.11",
+          "bundled": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "registry-auth-token": {
+          "version": "3.3.1",
+          "bundled": true
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "bundled": true
+        },
+        "remove-trailing-separator": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "renderkid": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true
+            }
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "resolve": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true
+        },
+        "ripemd160": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "bundled": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sane": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dependencies": {
+            "bser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "fb-watchman": {
+              "version": "1.9.2",
+              "bundled": true
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dependencies": {
+            "ajv": {
+              "version": "5.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "select-hose": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "selfsigned": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.15.3",
+          "bundled": true,
+          "dependencies": {
+            "debug": {
+              "version": "2.6.7",
+              "bundled": true
+            },
+            "mime": {
+              "version": "1.3.4",
+              "bundled": true
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.9.0",
+          "bundled": true
+        },
+        "serve-static": {
+          "version": "1.12.3",
+          "bundled": true
+        },
+        "serviceworker-cache-polyfill": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "settle-promise": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.8",
+          "bundled": true
+        },
+        "shell-quote": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "bundled": true
+        },
+        "shellwords": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "sockjs": {
+          "version": "0.3.18",
+          "bundled": true,
+          "dependencies": {
+            "faye-websocket": {
+              "version": "0.10.0",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "source-list-map": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.4.15",
+          "bundled": true
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "spdy": {
+          "version": "3.4.7",
+          "bundled": true
+        },
+        "spdy-transport": {
+          "version": "2.0.20",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "stream-http": {
+          "version": "2.7.2",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "string-length": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "style-loader": {
+          "version": "0.18.2",
+          "bundled": true
+        },
+        "supports-color": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "svgo": {
+          "version": "0.7.2",
+          "bundled": true
+        },
+        "sw-precache": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "sw-precache-webpack-plugin": {
+          "version": "0.11.3",
+          "bundled": true
+        },
+        "sw-toolbox": {
+          "version": "3.6.0",
+          "bundled": true
+        },
+        "symbol-observable": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "bundled": true
+        },
+        "table": {
+          "version": "3.8.3",
+          "bundled": true,
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.2.6",
+          "bundled": true
+        },
+        "test-exclude": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "throat": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "thunky": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "timers-browserify": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "tmp": {
+          "version": "0.0.31",
+          "bundled": true
+        },
+        "tmpl": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "toposort": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "tryit": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "type-is": {
+          "version": "1.6.15",
+          "bundled": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "ua-parser-js": {
+          "version": "0.7.13",
+          "bundled": true
+        },
+        "uglify-js": {
+          "version": "3.0.23",
+          "bundled": true
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ultron": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uniqid": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "uniqs": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "universalify": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unzip-response": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "urijs": {
+          "version": "1.18.10",
+          "bundled": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "url-loader": {
+          "version": "0.5.9",
+          "bundled": true
+        },
+        "url-parse": {
+          "version": "1.1.9",
+          "bundled": true,
+          "dependencies": {
+            "querystringify": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "utila": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "vendors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "walker": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "watch": {
+          "version": "0.10.0",
+          "bundled": true
+        },
+        "watchpack": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "wbuf": {
+          "version": "1.7.2",
+          "bundled": true
+        },
+        "webidl-conversions": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "webpack": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "loader-utils": {
+              "version": "0.2.17",
+              "bundled": true
+            },
+            "source-list-map": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true
+                }
+              }
+            },
+            "webpack-sources": {
+              "version": "0.2.3",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "6.6.0",
+              "bundled": true,
+              "dependencies": {
+                "camelcase": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dependencies": {
+                "camelcase": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.11.0",
+          "bundled": true
+        },
+        "webpack-dev-server": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true
+            },
+            "del": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "opn": {
+              "version": "4.0.2",
+              "bundled": true
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "sockjs-client": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "6.6.0",
+              "bundled": true
+            },
+            "yargs-parser": {
+              "version": "4.2.1",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-manifest-plugin": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dependencies": {
+            "fs-extra": {
+              "version": "0.30.0",
+              "bundled": true
+            },
+            "jsonfile": {
+              "version": "2.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "webpack-sources": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dependencies": {
+            "source-list-map": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "websocket-driver": {
+          "version": "0.6.5",
+          "bundled": true
+        },
+        "websocket-extensions": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "whatwg-encoding": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.13",
+              "bundled": true
+            }
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "4.8.0",
+          "bundled": true,
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "whet.extend": {
+          "version": "0.9.9",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.2.14",
+          "bundled": true
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "widest-line": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "worker-farm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "ws": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "xdg-basedir": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "xml-char-classes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "bundled": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "concurrently": "^3.5.0",
+    "discursor-app": "file:app",
     "express": "^4.15.3",
     "ws": "^3.0.0"
   },


### PR DESCRIPTION
Seems to work and should make e.g. Travis more straightforward. Also a reminder to switch off Travis builds for branches not yet including Travis configuration.